### PR TITLE
Fix editAssociations for menu items (#28314)

### DIFF
--- a/administrator/components/com_menus/models/item.php
+++ b/administrator/components/com_menus/models/item.php
@@ -9,6 +9,7 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\Registry\Registry;
 use Joomla\String\StringHelper;
 use Joomla\Utilities\ArrayHelper;
@@ -1551,6 +1552,11 @@ class MenusModelItem extends JModelAdmin
 
 			// Clean the cache
 			parent::cleanCache($option);
+		}
+
+		if (Factory::getApplication()->input->get('task') == 'editAssociations')
+		{
+			return $this->redirectToAssociations($data);
 		}
 
 		return true;

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -10,10 +10,11 @@ namespace Joomla\CMS\MVC\Model;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Factory;
+use Joomla\CMS\Language\LanguageHelper;
 use Joomla\Registry\Registry;
 use Joomla\String\StringHelper;
 use Joomla\Utilities\ArrayHelper;
-use Joomla\CMS\Language\LanguageHelper;
 
 /**
  * Prototype admin model.
@@ -1382,82 +1383,7 @@ abstract class AdminModel extends FormModel
 
 		if ($app->input->get('task') == 'editAssociations')
 		{
-			$id = $data['id'];
-
-			// Deal with categories associations
-			if ($this->text_prefix === 'COM_CATEGORIES')
-			{
-				$extension       = $app->input->get('extension', 'com_content');
-				$this->typeAlias = $extension . '.category';
-				$component       = strtolower($this->text_prefix);
-				$view            = 'category';
-			}
-			else
-			{
-				$aliasArray = explode('.', $this->typeAlias);
-				$component  = $aliasArray[0];
-				$view       = $aliasArray[1];
-				$extension  = '';
-			}
-
-			// Menu item redirect needs admin client
-			$client = $component === 'com_menus' ? '&client_id=0' : '';
-
-			if ($id == 0)
-			{
-				$app->enqueueMessage(\JText::_('JGLOBAL_ASSOCIATIONS_NEW_ITEM_WARNING'), 'error');
-				$app->redirect(
-					\JRoute::_('index.php?option=' . $component . '&view=' . $view . $client . '&layout=edit&id=' . $id . $extension, false)
-				);
-
-				return false;
-			}
-
-			if ($data['language'] === '*')
-			{
-				$app->enqueueMessage(\JText::_('JGLOBAL_ASSOC_NOT_POSSIBLE'), 'notice');
-				$app->redirect(
-					\JRoute::_('index.php?option=' . $component . '&view=' . $view . $client . '&layout=edit&id=' . $id . $extension, false)
-				);
-
-				return false;
-			}
-
-			$languages = LanguageHelper::getContentLanguages(array(0, 1));
-			$target    = '';
-
-			/* If the site contains only 2 languages and an association exists for the item
-			   load directly the associated target item in the side by side view
-			   otherwise select already the target language
-			*/
-			if (count($languages) === 2)
-			{
-				foreach ($languages as $language)
-				{
-					$lang_code[] = $language->lang_code;
-				}
-
-				$refLang    = array($data['language']);
-				$targetLang = array_diff($lang_code, $refLang);
-				$targetLang = implode(',', $targetLang);
-				$targetId   = $data['associations'][$targetLang];
-
-				if ($targetId)
-				{
-					$target = '&target=' . $targetLang . '%3A' . $targetId . '%3Aedit';
-				}
-				else
-				{
-					$target = '&target=' . $targetLang . '%3A0%3Aadd';
-				}
-			}
-
-			$app->redirect(
-				\JRoute::_(
-					'index.php?option=com_associations&view=association&layout=edit&itemtype=' . $this->typeAlias
-					. '&task=association.edit&id=' . $id . $target, false
-				)
-			);
+			return $this->redirectToAssociations($data);
 		}
 
 		return true;
@@ -1696,5 +1622,98 @@ abstract class AdminModel extends FormModel
 	{
 		// Save the item
 		$this->save($data);
+	}
+
+	/**
+	 * Method to load an item in com_associations.
+	 *
+	 * @param   array  $data  The form data.
+	 *
+	 * @return  boolean  True if successful, false otherwise.
+	 *
+	 * @throws \Exception
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function redirectToAssociations($data)
+	{
+		$app = Factory::getApplication();
+		$id  = $data['id'];
+
+		// Deal with categories associations
+		if ($this->text_prefix === 'COM_CATEGORIES')
+		{
+			$extension       = $app->input->get('extension', 'com_content');
+			$this->typeAlias = $extension . '.category';
+			$component       = strtolower($this->text_prefix);
+			$view            = 'category';
+		}
+		else
+		{
+			$aliasArray = explode('.', $this->typeAlias);
+			$component  = $aliasArray[0];
+			$view       = $aliasArray[1];
+			$extension  = '';
+		}
+
+		// Menu item redirect needs admin client
+		$client = $component === 'com_menus' ? '&client_id=0' : '';
+
+		if ($id == 0)
+		{
+			$app->enqueueMessage(\JText::_('JGLOBAL_ASSOCIATIONS_NEW_ITEM_WARNING'), 'error');
+			$app->redirect(
+				\JRoute::_('index.php?option=' . $component . '&view=' . $view . $client . '&layout=edit&id=' . $id . $extension, false)
+			);
+
+			return false;
+		}
+
+		if ($data['language'] === '*')
+		{
+			$app->enqueueMessage(\JText::_('JGLOBAL_ASSOC_NOT_POSSIBLE'), 'notice');
+			$app->redirect(
+				\JRoute::_('index.php?option=' . $component . '&view=' . $view . $client . '&layout=edit&id=' . $id . $extension, false)
+			);
+
+			return false;
+		}
+
+		$languages = LanguageHelper::getContentLanguages(array(0, 1));
+		$target    = '';
+
+		/* If the site contains only 2 languages and an association exists for the item
+		   load directly the associated target item in the side by side view
+		   otherwise select already the target language
+		*/
+		if (count($languages) === 2)
+		{
+			foreach ($languages as $language)
+			{
+				$lang_code[] = $language->lang_code;
+			}
+
+			$refLang    = array($data['language']);
+			$targetLang = array_diff($lang_code, $refLang);
+			$targetLang = implode(',', $targetLang);
+			$targetId   = $data['associations'][$targetLang];
+
+			if ($targetId)
+			{
+				$target = '&target=' . $targetLang . '%3A' . $targetId . '%3Aedit';
+			}
+			else
+			{
+				$target = '&target=' . $targetLang . '%3A0%3Aadd';
+			}
+		}
+
+		$app->redirect(
+			\JRoute::_(
+				'index.php?option=com_associations&view=association&layout=edit&itemtype=' . $this->typeAlias
+				. '&task=association.edit&id=' . $id . $target, false
+			)
+		);
+
+		return true;
 	}
 }


### PR DESCRIPTION
* Move editAssociations code back to own method so it can be explicitely called by child classes.

Co-authored-by: Richard Fath <richard67@users.noreply.github.com>

Pull Request for Issue # .

### Summary of Changes



### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

